### PR TITLE
[DEPENDENCY]: Replaced calls to the deprecated Ember.keys function wi…

### DIFF
--- a/addon/register.js
+++ b/addon/register.js
@@ -4,7 +4,7 @@ var registerWithApplication = function(dirName, application) {
     var directoryRegExp = new RegExp("^" + application.name + "/" + dirName);
     var require = window.require;
 
-    Ember.keys(require.entries).filter(function(key) {
+    Object.keys(require.entries).filter(function(key) {
         return directoryRegExp.test(key);
     }).forEach(function(moduleName) {
         var module = require(moduleName, null, null, true);


### PR DESCRIPTION
looks like ember 1.13.3 caused another fun dep warning ... this should fix it
